### PR TITLE
Mark as stale only enhancement PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,63 +7,19 @@ daysUntilStale: 60
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
 daysUntilClose: 7
 
-# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
-onlyLabels: []
-
-# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels:
-  - Hold
-  - Bug
-
-# Set to true to ignore issues in a project (defaults to false)
-exemptProjects: false
-
-# Set to true to ignore issues in a milestone (defaults to false)
-exemptMilestones: false
-
-# Set to true to ignore issues with an assignee (defaults to false)
-exemptAssignees: false
-
 # Label to use when marking as stale
 staleLabel: Stale
-
-# Comment to post when marking as stale. Set to `false` to disable
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
-
-# Comment to post when removing the stale label.
-# unmarkComment: >
-#   Your comment here.
-
-# Comment to post when closing a stale Issue or Pull Request.
-# closeComment: >
-#   Your comment here.
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30
 
-# Limit to only `issues` or `pulls`
-# only: issues
-
-# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
-issues:
-  # Comment to post when marking an issue as stale.
-  markComment: >
-    This issue has been automatically marked as stale.
-    **If this issue is still affecting you, please leave any comment**
-    (for example, "bump"), and we'll keep it open. We are sorry that we
-    haven't been able to prioritize it yet. If you have any new additional
-    information, please include it with your comment!
-
-  # Comment to post when closing a stale issue.
-  closeComment: >
-    Closing this issue after a prolonged period of inactivity. If this issue is
-    still present in the latest release, please create a new issue with
-    up-to-date information. Thank you!
+only: pulls
 
 pulls:
+  # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+  onlyLabels:
+    - Enhancement
+
   # Comment to post when marking a pull request as stale.
   markComment: >
     This pull request has been automatically marked as stale.
@@ -71,7 +27,6 @@ pulls:
     (for example, "bump"), and we'll keep it open. We are sorry that we
     haven't been able to prioritize reviewing it yet. Your contribution is
     very much appreciated.
-
   # Comment to post when closing a stale pull request.
   closeComment: >
     Closing this pull request after a prolonged period of inactivity. If this


### PR DESCRIPTION
If for some reason we miss triaging a PR, the Stale bot won't automatically mark it stale. I think this is a Good Thing (tm), since it doesn't penalize the PR author if we're not diligent with our PR housekeeping.

Issues will no longer be marked stale, since they will be either be kept in Issues as bugs, or converted as discussions.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- ~[ ] I have attached screenshots to demo visual changes.~
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~
